### PR TITLE
Set up e2e testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  unit:
     strategy:
       matrix:
         go-version: [1.18.x]
@@ -24,3 +24,28 @@ jobs:
       uses: actions/checkout@v3
     - name: Unit Test
       run: make test
+  e2e:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+    - name: Create k8s Kind Cluster
+      uses: helm/kind-action@v1.3.0
+      with:
+        config: test/e2e/kind/config.yaml
+        cluster_name: kubearchive-testing
+        version: v0.15.0
+        kubectl_version: v1.25.0
+    - name: Set up ingress
+      run: make setup-ingress
+    - name: Build container image
+      run: make container-build IMG=localhost/kubearchive:testing
+    - name: Load image into KinD
+      run: make container-load-kind KIND=$(which kind) IMG=localhost/kubearchive:testing
+    - name: Deploy kubearchive
+      run: make deploy IMG=localhost/kubearchive:testing
+    - name: E2E test
+      run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/kubearchive:latest
+IMG ?= ghcr.io/adambkaplan/kubearchive:main
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
 
@@ -58,6 +58,23 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+KUBEARCHIVE_HOSTNAME ?= localhost:8080
+
+.PHONY: test-e2e
+test-e2e: ## Run e2e tests
+	KUBEARCHIVE_TEST_SUITE=e2e KUBEARCHIVE_HOSTNAME=${KUBEARCHIVE_HOSTNAME} go test ./test/e2e/...
+
+KIND_CLUSTER_NAME ?= kubearchive-testing
+
+.PHONY: setup-kind
+setup-kind: kind ## Set up a KinD cluster for testing
+	$(KIND) create cluster --config test/e2e/kind/config.yaml --name=${KIND_CLUSTER_NAME}
+
+.PHONY: setup-ingress
+setup-ingress: ## Set up the NGINX ingress controller on a cluster. Optional
+	kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+	kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s
+
 ##@ Build
 
 .PHONY: build
@@ -71,12 +88,16 @@ run: manifests generate fmt vet ## Run a controller from your host.
 CONTAINER_ENGINE ?= docker
 
 .PHONY: container-build
-container-build: test ## Build container image with the manager.
+container-build: ## Build container image with kubearchive.
 	${CONTAINER_ENGINE} build -t ${IMG} .
 
 .PHONY: container-push
-container-push: ## Push docker image with the manager.
+container-push: ## Push container image with kubearchive.
 	${CONTAINER_ENGINE} push ${IMG}
+
+.PHONY: container-load-kind
+container-load-kind: kind ## Push a (local) docker image into a KinD cluster
+	$(KIND) load docker-image ${IMG} --name ${KIND_CLUSTER_NAME}
 
 ##@ Deployment
 
@@ -114,10 +135,12 @@ $(LOCALBIN):
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+KIND ?= $(LOCALBIN)/kind
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.9.2
+KIND_VERSION ?= v0.15.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -134,3 +157,8 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+.PHONY: kind
+kind: $(KIND) ## Download and install KinD if necessary
+$(KIND): $(LOCALBIN)
+	test -s $(LOCALBIN)/kind || { curl -Lo $(LOCALBIN)/kind https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-linux-amd64 && chmod +x $(LOCALBIN)/kind; }

--- a/test/e2e/archive_test.go
+++ b/test/e2e/archive_test.go
@@ -1,0 +1,35 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("archive REST api", func() {
+
+	It("returns \"hello\" from /archive", func() {
+		hostname := os.Getenv("KUBEARCHIVE_HOSTNAME")
+		if len(hostname) == 0 {
+			hostname = "localhost:8080"
+		}
+
+		testURL := fmt.Sprintf("http://%s/archive", hostname)
+		resp, err := http.Get(testURL)
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		result := map[string]string{}
+		err = json.Unmarshal(body, &result)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(result["message"]).To(Equal("hello"))
+
+	})
+})

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -1,0 +1,24 @@
+package framework
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IsDeploymentReady(ctx context.Context, c client.Client, namespace string, name string) (bool, error) {
+	deployment := &appsv1.Deployment{}
+	err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, deployment)
+	if err != nil {
+		return false, err
+	}
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type != appsv1.DeploymentAvailable {
+			continue
+		}
+		return condition.Status == corev1.ConditionTrue, nil
+	}
+	return false, nil
+}

--- a/test/e2e/kind/config.yaml
+++ b/test/e2e/kind/config.yaml
@@ -1,0 +1,22 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://kind-registry:5000"]
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 8080
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 8443
+    protocol: TCP
+

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,0 +1,62 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/adambkaplan/kubearchive/test/e2e/framework"
+)
+
+var (
+	kubeClient  client.Client
+	testContext context.Context
+	cancel      context.CancelFunc
+)
+
+func TestE2E(t *testing.T) {
+	suite := os.Getenv("KUBEARCHIVE_TEST_SUITE")
+	if suite != "e2e" {
+		t.Skip("skipping e2e test because KUBEARCHIVE_TEST_SUITE=e2e was not set")
+	}
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	rest, err := ctrl.GetConfig()
+	Expect(err).NotTo(HaveOccurred())
+
+	kubeClient, err = client.New(rest, client.Options{
+		Scheme: scheme,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	testContext, cancel = context.WithCancel(context.Background())
+})
+
+var _ = BeforeEach(func() {
+	By("waiting for project deployment")
+	err := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+		return framework.IsDeploymentReady(testContext, kubeClient, "kubearchive", "kubearchive-controller-manager")
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+})


### PR DESCRIPTION
- Fix default image for build and deployment
- Add setup-kind Makefile targets to configure a cluster for testing
- Add setup-ingress target to configure the NGINX ingress controller for clusters that need ingress configured.
- Add container-load-kind target to load a container image into KinD
- Add e2e tests, which for now check that the archive endpoint returns a "hello" message.
- Add GitHub action to run e2e test against a KinD cluster.